### PR TITLE
Add convcoord experiment

### DIFF
--- a/mdrc_pacbot_rl/experiments/coordconv_ppo.py
+++ b/mdrc_pacbot_rl/experiments/coordconv_ppo.py
@@ -17,7 +17,7 @@ from torch.distributions import Categorical
 from tqdm import tqdm
 
 from mdrc_pacbot_rl.algorithms.rollout_buffer import RolloutBuffer
-from mdrc_pacbot_rl.pacman.gym import PacmanGym
+from mdrc_pacbot_rl.pacman.gym import NaivePacmanGym as PacmanGym
 from mdrc_pacbot_rl.utils import copy_params, get_img_size, init_orthogonal
 
 _: Any
@@ -231,14 +231,17 @@ for _ in tqdm(range(iterations), position=0):
     with torch.no_grad():
         # Visualize
         reward_total = 0
+        score_total = 0
         entropy_total = 0.0
         eval_obs = torch.Tensor(test_env.reset()[0])
         for _ in range(eval_steps):
             avg_entropy = 0.0
             steps_taken = 0
+            score = 0
             for _ in range(max_eval_steps):
                 distr = Categorical(logits=p_net(eval_obs.unsqueeze(0)).squeeze())
                 action = distr.sample().item()
+                score = test_env.score()
                 obs_, reward, eval_done, _, _ = test_env.step(action)
                 eval_obs = torch.Tensor(obs_)
                 steps_taken += 1
@@ -249,10 +252,12 @@ for _ in tqdm(range(iterations), position=0):
                     break
             avg_entropy /= steps_taken
             entropy_total += avg_entropy
+            score_total += score
 
     wandb.log(
         {
             "avg_eval_episode_reward": reward_total / eval_steps,
+            "avg_eval_episode_score": score_total / eval_steps,
             "avg_eval_entropy": entropy_total / eval_steps,
             "avg_v_loss": total_v_loss / train_iters,
             "avg_p_loss": total_p_loss / train_iters,


### PR DESCRIPTION
### What does the PR do?
Adds an experiment that uses a ConvCoord layer for the value and policy networks. ConvCoord has been shown to improve convergence and/or performance in a number of tasks where an image input is converted to a discrete output. Details on ConvCoord: https://www.uber.com/blog/coordconv/