### PR TITLE
Allow assigning to Rust ghost positions

### DIFF
--- a/pacbot_rs/src/game_state/py_wrappers.rs
+++ b/pacbot_rs/src/game_state/py_wrappers.rs
@@ -63,6 +63,19 @@ impl GhostPosWrapper {
             }
         })
     }
+
+    fn __setitem__(&self, item: &str, pos: (usize, usize)) -> PyResult<()> {
+        Python::with_gil(|py| {
+            let game_state = self.game_state.borrow(py);
+            let mut ghost = (self.get_ghost)(&game_state).borrow_mut();
+            match item {
+                "current" => ghost.current_pos = pos,
+                "next" => ghost.next_pos = pos,
+                _ => return Err(PyKeyError::new_err(item.to_owned())),
+            }
+            Ok(())
+        })
+    }
 }
 
 pub(super) fn wrap_ghost_agent(


### PR DESCRIPTION
This PR allows setting the positions of ghosts in the Rust `GameState`, e.g.

```rs
game_state.blue.pos["current"] = (4, 5)
```